### PR TITLE
Use `pgrep` rather than `kill 0`

### DIFF
--- a/discover-vnc.sh
+++ b/discover-vnc.sh
@@ -22,9 +22,9 @@ while read -r line; do
     if [ $(echo $line | cut -d ' ' -f 3) -ne '3' ]; then
         break
     fi
-done < <((sleep 0.5; kill -13 0) & # kill quickly if trapped
+done < <((sleep 0.5; pgrep -q dns-sd && kill -13 $(pgrep dns-sd)) & # kill quickly if trapped
             dns-sd -B _rfb._tcp)
 
-# kill child processes
-kill -13 0
+# kill dns-sd child process
+pgrep -q dns-sd && kill -13 $(pgrep dns-sd)
 exit 0


### PR DESCRIPTION
If we try and kill the child process using 
`kill -13 0`, then when this command is itself run 
in a subshell, e.g.

```
for vnc in $(./discover-vnc.sh); do echo "Found $vnc"; done
```

then the `kill -13 0` terminates the calling shell. 

Instead, it's better to grep for the backgrounded 
`dns-sd` process by name, and kill it when found:

```
pgrep -q dns-sd && kill -13 $(pgrep dns-sd)
```
